### PR TITLE
Add font weight to active tab

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -53,6 +53,7 @@ const MenuItem = styled.a`
   padding: 0.5rem 2.75rem;
   &.is-active {
     text-decoration: underline;
+    font-weight: 500;
   }
 `;
 

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -52,7 +52,6 @@ const MenuItem = styled.a`
   font-size: 18px;
   padding: 0.5rem 2.75rem;
   &.is-active {
-    text-decoration: underline;
     font-weight: 500;
   }
 `;


### PR DESCRIPTION
* Add Font weight
* Remove underline _(removing underline improves the design)_

![image](https://user-images.githubusercontent.com/29014463/53264684-3af35a80-3702-11e9-92b8-d0c2e9af597d.png)

Closes issue https://github.com/dexlab-io/dexpay-pos/issues/77